### PR TITLE
Update eslint to 5.x, remove deprecated option

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -5,10 +5,7 @@ module.exports = {
   extends: './index.js',
 
   parserOptions: {
-    ecmaVersion: 6,
-    ecmaFeatures: {
-      experimentalObjectRestSpread: true
-    }
+    ecmaVersion: 2018
   },
 
   env: {

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
     "url": "https://github.com/wearereasonablepeople/eslint-config-warp/issues"
   },
   "peerDependencies": {
-    "eslint": "4.x.x"
+    "eslint": "5.x.x"
   },
   "homepage": "https://github.com/wearereasonablepeople/eslint-config-warp#readme",
   "devDependencies": {
-    "eslint": "4.x.x",
+    "eslint": "5.x.x",
     "xyz": "^3.0.0"
   }
 }


### PR DESCRIPTION
Should address issue pointed out in https://github.com/wearereasonablepeople/authomatic/pull/34#issuecomment-399664100

Migration guide, section about deprecation: https://eslint.org/docs/user-guide/migrating-to-5.0.0#-the-experimentalobjectrestspread-option-has-been-deprecated