### PR TITLE
Remove eslint-config-standard-react

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Preset | Description | Load Order | Dependencies
 `warp` | Base JavaScript (ES5) linting rules | First |
 `warp/node` | Linting rules for Node.JS | Soon after `warp` | `eslint-plugin-node`
 `warp/es6` | Linting rules for ES6 language features | Soon after `warp` |
-`warp/jsx` | Linting rules for React JSX | Soon after `warp` | `eslint-config-standard-react eslint-plugin-react`
+`warp/jsx` | Linting rules for React JSX | Soon after `warp` | `eslint-plugin-react`
 `warp/module` | Linting rules for modular JavaScript | Near the end | `eslint-plugin-import`
 `warp/typescript` | Linting rules for TypeScript files; implies `warp/module` | Near the end | `eslint-plugin-import @typescript-eslint/eslint-plugin @typescript-eslint/parser`
 

--- a/jsx.js
+++ b/jsx.js
@@ -2,7 +2,7 @@
 
 module.exports = {
 
-  extends: ['plugin:react/recommended', 'standard-react'],
+  extends: ['plugin:react/recommended'],
 
   plugins: ['react'],
 
@@ -41,6 +41,11 @@ module.exports = {
     'react/jsx-max-depth': [0],
     'react/jsx-max-props-per-line': [0],
     'react/jsx-newline': [2, {prevent: true}],
+    'react/jsx-no-bind': [2, {
+      allowArrowFunctions: true,
+      allowBind: false,
+      ignoreRefs: true,
+    }],
     'react/jsx-no-constructed-context-values': [2],
     'react/jsx-no-literals': [0],
     'react/jsx-no-script-url': [0],
@@ -66,12 +71,14 @@ module.exports = {
     'react/no-array-index-key': [2],
     'react/no-danger': [2],
     'react/no-did-mount-set-state': [2],
+    'react/no-did-update-set-state': [2],
     'react/no-multi-comp': [2, {ignoreStateless: true}],
     'react/no-redundant-should-component-update': [2],
     'react/no-set-state': [0],
     'react/no-this-in-sfc': [2],
     'react/no-typos': [2],
     'react/no-unstable-nested-components': [2, {allowAsProps: true}],
+    'react/no-unused-prop-types': [2],
     'react/no-unused-state': [2],
     'react/no-will-update-set-state': [2],
     'react/prefer-es6-class': [2],

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@typescript-eslint/eslint-plugin": ">=4.26.1",
     "@typescript-eslint/parser": ">=4.26.1",
     "eslint": ">=5.0.0",
-    "eslint-config-standard-react": ">=9.2.0",
     "eslint-plugin-node": ">=11.1.0",
     "eslint-plugin-react": ">=7.22.0"
   },
@@ -35,7 +34,6 @@
     "@typescript-eslint/eslint-plugin": "^5.15.0",
     "@typescript-eslint/parser": "^5.15.0",
     "eslint": "^8.10.0",
-    "eslint-config-standard-react": "standard/eslint-config-standard-react#78895eeb0f29794552ed6146dcc1f5a79e768ce0",
     "eslint-find-rules": "^4.1.0",
     "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-node": "^11.1.0",


### PR DESCRIPTION
# Motivation
Instead of waiting for the new version to be released, we can just get rid of the dependency.

# Changes
- Added 3 linting rules to `warp/jsx`, configured as they were in the [eslint-config-standard-react](https://github.com/standard/eslint-config-standard-react/blob/master/eslintrc.json)