### PR TITLE
Update no-alert and no-console to generate errors instead of warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,11 +7,11 @@ module.exports = {
   rules: {
 
     // Warnings.
-    'no-alert': [1],
-    'no-console': [1],
     'no-warning-comments': [1, {terms: ['todo', 'tmp', 'temp', 'temporary', 'fixme']}],
 
     // Best practices.
+    'no-alert': [2],
+    'no-console': [2],
     'no-prototype-builtins': [2],
     'array-callback-return': [2],
     'consistent-return': [2],


### PR DESCRIPTION
The idea is that warnings should only be used for code that may require a refactor, but is fine to commit anyway.

Console and alert statements are one of:

- Undesirable, in which case we want the CI to fail; or
- Explicitly desired, in which case the error can be suppressed by a comment.

When these rules generate warnings as opposed to errors, we:

1. Accept that the undesirable statements may be merged to main (CI does not fail).
2. We train ourselves to suppress warnings, which we shouldn't be doing.